### PR TITLE
Fix type hints in DataFrameAccessor

### DIFF
--- a/MatplotLibAPI/__init__.py
+++ b/MatplotLibAPI/__init__.py
@@ -135,7 +135,7 @@ class DataFrameAccessor:
                     max_values: int = 20,
                     sort_by: Optional[str] = None,
                     ascending: bool = False,
-                    figsize: Tuple[float, float] = (19.2, 10.8)) -> Axes:
+                    figsize: Tuple[float, float] = (19.2, 10.8)) -> Figure:
         """Return a figure containing the table plot."""
         return fplot_table(pd_df=self._obj,
                            cols=cols,
@@ -180,7 +180,7 @@ class DataFrameAccessor:
                         sort_by: Optional[str] = None,
                         ascending: bool = False,
                         std: bool = False,
-                        figsize: Tuple[float, float] = (19.2, 10.8)) -> Axes:
+                        figsize: Tuple[float, float] = (19.2, 10.8)) -> Figure:
         """Return a figure plotting the time series."""
         return fplot_timeserie(pd_df=self._obj,
                                label=label,
@@ -221,13 +221,13 @@ class DataFrameAccessor:
                                  target: str = "target",
                                  weight: str = "weight",
                                  title: Optional[str] = None,
-                                 style: StyleTemplate = NETWORK_STYLE_TEMPLATE,
-                                 sort_by: Optional[str] = None,
-                                 ascending: bool = False,
-                                 node_list: Optional[List] = None,
-                                 ax: Optional[Axes] = None) -> Axes:
+                                style: StyleTemplate = NETWORK_STYLE_TEMPLATE,
+                                sort_by: Optional[str] = None,
+                                ascending: bool = False,
+                                node_list: Optional[List] = None,
+                                ax: Optional[List[Axes]] = None) -> List[Axes]:
         """Plot connected components of the network graph."""
-        return aplot_network_components(df=self._obj,
+        return aplot_network_components(pd_df=self._obj,
                                         source=source,
                                         target=target,
                                         weight=weight,
@@ -246,7 +246,7 @@ class DataFrameAccessor:
                       style: StyleTemplate = NETWORK_STYLE_TEMPLATE,
                       sort_by: Optional[str] = None,
                       ascending: bool = False,
-                      node_list: Optional[List] = None) -> Axes:
+                      node_list: Optional[List] = None) -> Figure:
         """Return a network plot as a new figure."""
         return fplot_network(pd_df=self._obj,
                              source=source,
@@ -289,7 +289,7 @@ class DataFrameAccessor:
                       sort_by: Optional[str] = None,
                       max_values: int = 100,
                       ascending: bool = False,
-                      fig: Optional[go.Figure] = None) -> go.Figure:
+                      fig: Optional[go.Figure] = None) -> go.Trace:
         """Add a treemap trace to an existing figure or create a new one."""
         return aplot_treemap(pd_df=self._obj,
                              path=path,
@@ -310,7 +310,7 @@ class DataFrameAccessor:
                       sort_by: Optional[str] = None,
                       max_values: int = 100,
                       ascending: bool = False,
-                      fig: Optional[go.Figure] = None) -> go.Figure:
+                      fig: Optional[go.Figure] = None) -> Optional[go.Figure]:
         """Return a figure composed of multiple treemap plots."""
         pd_dfs: Dict[str, pd.DataFrame] = {}
         for path in pathes:
@@ -326,5 +326,17 @@ class DataFrameAccessor:
                              max_values=max_values)
 
 
-__all__ = ["validate_dataframe", "aplot_bubble", "aplot_timeserie", "aplot_table", "aplot_network", "aplot_network_components", "fplot_network",
-           "plot_pivotbar", "fplot_treemap", "aplot_treemap", "plot_composite_bubble","plot_composite_treemap", "StyleTemplate", "DataFrameAccessor"]
+__all__ = [
+    "aplot_bubble",
+    "aplot_timeserie",
+    "aplot_table",
+    "aplot_network",
+    "aplot_network_components",
+    "fplot_network",
+    "fplot_treemap",
+    "aplot_treemap",
+    "plot_composite_bubble",
+    "plot_composite_treemap",
+    "StyleTemplate",
+    "DataFrameAccessor",
+]


### PR DESCRIPTION
## Summary
- correct return types for figure-producing accessors
- align network component helpers with list-based signatures
- clean package exports

## Testing
- `pydocstyle MatplotLibAPI`
- `pyright MatplotLibAPI/__init__.py`
- `pyright MatplotLibAPI`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f36bc4f148329a89d44fe5c0ea0ca