### PR TITLE
Fix import cycle and restore pivot bar kwargs behavior

### DIFF
--- a/src/MatplotLibAPI/__init__.py
+++ b/src/MatplotLibAPI/__init__.py
@@ -1,9 +1,6 @@
 """Public API and pandas accessor for MatplotLibAPI."""
 
-from typing_extensions import TypeAlias
-from typing import Literal
 from .accessor import DataFrameAccessor
+from .types import CorrelationMethod
 
-CorrelationMethod: TypeAlias = Literal["pearson", "kendall", "spearman"]
-
-__all__ = ["DataFrameAccessor"]
+__all__ = ["DataFrameAccessor", "CorrelationMethod"]

--- a/src/MatplotLibAPI/accessor.py
+++ b/src/MatplotLibAPI/accessor.py
@@ -21,7 +21,7 @@ from .style_template import (
     StyleTemplate,
 )
 
-from . import CorrelationMethod
+from .types import CorrelationMethod
 
 if TYPE_CHECKING:
     import plotly.graph_objects as go

--- a/src/MatplotLibAPI/heatmap.py
+++ b/src/MatplotLibAPI/heatmap.py
@@ -8,7 +8,7 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from .base_plot import BasePlot
-from . import CorrelationMethod
+from .types import CorrelationMethod
 from .style_template import (
     HEATMAP_STYLE_TEMPLATE,
     StyleTemplate,

--- a/src/MatplotLibAPI/pivot.py
+++ b/src/MatplotLibAPI/pivot.py
@@ -111,7 +111,7 @@ class PivotBarChart(BasePlot):
             "kind": "bar",
             "x": self.x,
             "stacked": self.stacked,
-            "ax": ax,
+            "ax": plot_ax,
             "alpha": 0.7,
         }
         pivot_df.plot(**BasePlot.merge_kwargs(plot_kwargs, kwargs))

--- a/src/MatplotLibAPI/types.py
+++ b/src/MatplotLibAPI/types.py
@@ -1,0 +1,6 @@
+"""Shared type aliases for MatplotLibAPI."""
+
+from typing import Literal
+from typing_extensions import TypeAlias
+
+CorrelationMethod: TypeAlias = Literal["pearson", "kendall", "spearman"]


### PR DESCRIPTION
### Motivation
- Tests were failing during collection due to a circular import: `accessor.py` imported a type alias defined in package init which caused a partially initialized package error.  
- Pivoted bar plotting forwarded kwargs (for example `alpha`) were not applied to the rendered bar patches because the DataFrame plot was given the original `ax` instead of the resolved axis object.  

### Description
- Add a dedicated `src/MatplotLibAPI/types.py` module and move the `CorrelationMethod` type alias there to avoid package initialization circular imports.  
- Update imports to use `from .types import CorrelationMethod` in `__init__.py`, `accessor.py`, and `heatmap.py`, and export `CorrelationMethod` from the package public API.  
- Fix `PivotBarChart.aplot` to pass the resolved axis (`plot_ax`) into `pivot_df.plot(...)` so forwarded kwargs are applied to the plotted artists and the returned axes match the rendered content.  

### Testing
- Ran style and static checks: `black --check .`, `pydocstyle src`, and `pyright src` and all passed.  
- Ran unit tests and coverage: `pytest -q --cov=src --cov-report=term-missing --cov-fail-under=70` which completed successfully with `73 passed` and overall coverage ~78.9%.  
- Also ran the focused pivot tests `pytest -q tests/test_pivot.py` which passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfaaa394648329a3d6a70da72832c1)