### PR TITLE
Add degree_distribution property to NetworkGraph

### DIFF
--- a/src/MatplotLibAPI/network/core.py
+++ b/src/MatplotLibAPI/network/core.py
@@ -467,6 +467,19 @@ class NetworkGraph(BasePlot):
             distribution[int(degree)] += 1
         return dict(sorted(distribution.items()))
 
+    @property
+    def degree_sequence(self) -> List[int]:
+        """Return node degrees sorted in descending order.
+
+        Returns
+        -------
+        list[int]
+            Degree for each node sorted from highest to lowest.
+        """
+        return sorted(
+            (int(degree) for _, degree in self._nx_graph.degree()), reverse=True
+        )
+
     def add_node(self, node: Any, **attributes: Any):
         """Add a node with optional attributes.
 

--- a/src/MatplotLibAPI/network/core.py
+++ b/src/MatplotLibAPI/network/core.py
@@ -453,6 +453,20 @@ class NetworkGraph(BasePlot):
         """Return the degree assortativity coefficient of the graph."""
         return nx.degree_assortativity_coefficient(self._nx_graph)
 
+    @property
+    def degree_distribution(self) -> Dict[int, int]:
+        """Return the count of nodes for each degree.
+
+        Returns
+        -------
+        dict[int, int]
+            Mapping from node degree to number of nodes with that degree.
+        """
+        distribution: Dict[int, int] = defaultdict(int)
+        for _, degree in self._nx_graph.degree():
+            distribution[int(degree)] += 1
+        return dict(sorted(distribution.items()))
+
     def add_node(self, node: Any, **attributes: Any):
         """Add a node with optional attributes.
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -152,6 +152,17 @@ def test_scale_weights_respects_precomputed_deciles():
     assert _scale_weights(weights, deciles=deciles) == expected
 
 
+def test_degree_distribution_returns_node_counts_by_degree():
+    """Return the count of nodes grouped by their degree."""
+
+    graph = NetworkGraph()
+    graph.add_edge("a", "b")
+    graph.add_edge("b", "c")
+    graph.add_node("isolated")
+
+    assert graph.degree_distribution == {0: 1, 1: 2, 2: 1}
+
+
 def test_network_layout_respects_precomputed_deciles() -> None:
     """Reuse provided deciles to produce stable layout scaling."""
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -163,6 +163,17 @@ def test_degree_distribution_returns_node_counts_by_degree():
     assert graph.degree_distribution == {0: 1, 1: 2, 2: 1}
 
 
+def test_degree_sequence_returns_descending_node_degrees():
+    """Return node degrees sorted from highest to lowest."""
+
+    graph = NetworkGraph()
+    graph.add_edge("a", "b")
+    graph.add_edge("b", "c")
+    graph.add_node("isolated")
+
+    assert graph.degree_sequence == [2, 1, 1, 0]
+
+
 def test_network_layout_respects_precomputed_deciles() -> None:
     """Reuse provided deciles to produce stable layout scaling."""
 


### PR DESCRIPTION
### Motivation
- Provide a simple API to obtain the degree distribution (counts of nodes by degree) for `NetworkGraph` instances to support analysis and plotting without manual aggregation.
- Ensure isolated nodes are included and that the output is ordered by degree for predictable downstream usage.

### Description
- Add a new `degree_distribution` property to `NetworkGraph` in `src/MatplotLibAPI/network/core.py` that returns a `dict[int, int]` mapping degree to node count, sorted by degree.
- Implement the property using a `defaultdict(int)` to aggregate degrees from `self._nx_graph.degree()` and convert the result to a sorted dict. 
- Add a unit test `test_degree_distribution_returns_node_counts_by_degree` in `tests/test_network.py` that verifies mixed-degree and isolated-node behavior (`{0: 1, 1: 2, 2: 1}`).

### Testing
- Ran `pytest -q tests/test_network.py` and the targeted tests all passed (`15 passed`).
- Ran the full test suite with coverage via `pytest -q --cov=MatplotLibAPI --cov-report=term-missing --cov-fail-under=70` and all tests passed (`74 passed`) and total coverage met the threshold.
- Ran style and static checks: `pydocstyle src/MatplotLibAPI tests/test_network.py`, `black --check src/MatplotLibAPI/network/core.py tests/test_network.py`, and `pyright src/MatplotLibAPI`, all of which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe8eef93c832987ea1752a9995fed)