### PR TITLE
Add regression test to ensure fplot_network forwards layout_seed to NetworkGraph.fplot

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -121,6 +121,30 @@ def test_accessor_fplot_network_forwards_layout_seed(monkeypatch):
     assert captured_layout_seed == [123]
 
 
+def test_fplot_network_forwards_layout_seed_to_graph_fplot(monkeypatch):
+    """Forward ``layout_seed`` from wrapper to ``NetworkGraph.fplot``."""
+
+    df = pd.DataFrame(
+        {
+            "source": ["a", "b", "c"],
+            "target": ["b", "c", "a"],
+            "weight": [1, 2, 3],
+        }
+    )
+    captured_layout_seed = []
+
+    def fake_fplot(self, *args, **kwargs):  # type: ignore[override]
+        captured_layout_seed.append(kwargs.get("layout_seed"))
+        return plt.figure()
+
+    monkeypatch.setattr(NetworkGraph, "fplot", fake_fplot)
+
+    fig = fplot_network(df, layout_seed=99)
+
+    assert isinstance(fig, Figure)
+    assert captured_layout_seed == [99]
+
+
 def test_softmax_matches_expected_probabilities():
     """Return softmax probabilities consistent with NumPy operations."""
 


### PR DESCRIPTION
### Motivation
- Ensure the `fplot_network` wrapper forwards the `layout_seed` argument into `NetworkGraph.fplot` so layout reproducibility controlled via the accessor and wrapper is preserved.

### Description
- Add `test_fplot_network_forwards_layout_seed_to_graph_fplot` to `tests/test_network.py` which monkeypatches `NetworkGraph.fplot` to capture the forwarded `layout_seed`, while keeping the existing accessor-level forwarding test.

### Testing
- Ran `pytest -q tests/test_network.py -k "fplot_network_forwards_layout_seed or accessor_fplot_network_forwards_layout_seed"` and the tests passed (`2 passed, 17 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de483b0d6c8329be9c76312ffbcefe)