### PR TITLE
test: lock the supported public plotting API

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,14 @@
+"""Regression tests for the supported package-root API."""
+
+import MatplotLibAPI
+
+
+def test_public_api_is_explicit() -> None:
+    """Expose only the documented package-root symbols."""
+    assert MatplotLibAPI.__all__ == ["DataFrameAccessor", "CorrelationMethod"]
+
+
+def test_public_api_symbols_are_importable() -> None:
+    """Keep supported root imports available to downstream users."""
+    for name in MatplotLibAPI.__all__:
+        assert getattr(MatplotLibAPI, name) is not None


### PR DESCRIPTION
Implements #73.

- verifies the explicit package-root `__all__`
- adds regression coverage for every supported root import
- prevents accidental public API drift