### PR TITLE
feat: lock the supported package-root plotting API

### DIFF
--- a/src/MatplotLibAPI/__init__.py
+++ b/src/MatplotLibAPI/__init__.py
@@ -1,6 +1,40 @@
-"""Public API and pandas accessor for MatplotLibAPI."""
+"""Supported public API for MatplotLibAPI.
+
+The names exported here form the stable package-root import surface. Internal
+helpers and implementation classes should be imported from their modules.
+"""
 
 from .accessor import DataFrameAccessor
+from .area import fplot_area
+from .bar import fplot_bar
+from .box_violin import fplot_box_violin
+from .heatmap import fplot_correlation_matrix, fplot_heatmap
+from .histogram import fplot_histogram_kde
+from .pie import fplot_pie_donut
+from .sankey import fplot_sankey
+from .sunburst import fplot_sunburst
+from .table import fplot_table
+from .timeserie import fplot_timeserie
+from .treemap import fplot_treemap
 from .types import CorrelationMethod
+from .waffle import fplot_waffle
+from .word_cloud import fplot_wordcloud
 
-__all__ = ["DataFrameAccessor", "CorrelationMethod"]
+__all__ = [
+    "CorrelationMethod",
+    "DataFrameAccessor",
+    "fplot_area",
+    "fplot_bar",
+    "fplot_box_violin",
+    "fplot_correlation_matrix",
+    "fplot_heatmap",
+    "fplot_histogram_kde",
+    "fplot_pie_donut",
+    "fplot_sankey",
+    "fplot_sunburst",
+    "fplot_table",
+    "fplot_timeserie",
+    "fplot_treemap",
+    "fplot_waffle",
+    "fplot_wordcloud",
+]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -3,12 +3,32 @@
 import MatplotLibAPI
 
 
+EXPECTED_PUBLIC_API = {
+    "CorrelationMethod",
+    "DataFrameAccessor",
+    "fplot_area",
+    "fplot_bar",
+    "fplot_box_violin",
+    "fplot_correlation_matrix",
+    "fplot_heatmap",
+    "fplot_histogram_kde",
+    "fplot_pie_donut",
+    "fplot_sankey",
+    "fplot_sunburst",
+    "fplot_table",
+    "fplot_timeserie",
+    "fplot_treemap",
+    "fplot_waffle",
+    "fplot_wordcloud",
+}
+
+
 def test_public_api_is_explicit() -> None:
-    """Expose only the documented package-root symbols."""
-    assert MatplotLibAPI.__all__ == ["DataFrameAccessor", "CorrelationMethod"]
+    """Expose exactly the documented package-root symbols."""
+    assert set(MatplotLibAPI.__all__) == EXPECTED_PUBLIC_API
 
 
 def test_public_api_symbols_are_importable() -> None:
-    """Keep supported root imports available to downstream users."""
-    for name in MatplotLibAPI.__all__:
+    """Resolve every supported root export."""
+    for name in EXPECTED_PUBLIC_API:
         assert getattr(MatplotLibAPI, name) is not None


### PR DESCRIPTION
## Summary

- expose the documented plotting helpers from `MatplotLibAPI`
- define the supported root API explicitly through `__all__`
- add regression coverage for the exact public surface and importability

Closes #73.

## Validation

CI should run formatting, typing, tests, and package validation for this branch.