### PR TITLE
quality: lock plotting parameter and return contracts

### DIFF
--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -1,0 +1,51 @@
+# Public plotting API contract
+
+This document defines the stable package-root plotting contract for MatplotLibAPI.
+
+## Universal rules
+
+Every plotting helper exported from `MatplotLibAPI.__all__` follows these rules:
+
+1. Tabular input is named `pd_df` and accepts a pandas `DataFrame`.
+2. Figure helpers are named `fplot_*` and return a Matplotlib `Figure`.
+3. Existing keyword names remain supported within the current major version.
+4. Shared concepts use the names below when they apply.
+
+## Shared parameter vocabulary
+
+| Concept | Canonical name | Meaning |
+| --- | --- | --- |
+| DataFrame | `pd_df` | Input pandas DataFrame. |
+| Horizontal field | `x` | Column mapped to the horizontal axis. |
+| Vertical field | `y` | Column mapped to the vertical axis. |
+| Numeric measure | `value` | Column containing values to aggregate or display. |
+| Category | `category` | Primary categorical grouping. |
+| Secondary grouping | `group` | Series, color, or stack grouping. |
+| Series label | `label` | Column identifying a plotted series. |
+| Plot title | `title` | Human-readable figure title. |
+| Figure size | `figsize` | Matplotlib figure size tuple. |
+
+Chart-specific structural names such as `source`, `target`, `parents`, `labels`, `index`, and `columns` remain explicit because replacing them with generic aliases would reduce clarity.
+
+## Package-root signature matrix
+
+| Helper | Primary fields | Optional grouping | Return |
+| --- | --- | --- | --- |
+| `fplot_area` | `x`, `y` | `label` | `Figure` |
+| `fplot_bar` | `category`, `value` | `group` | `Figure` |
+| `fplot_box_violin` | `column` | `category` | `Figure` |
+| `fplot_correlation_matrix` | numeric DataFrame columns | — | `Figure` |
+| `fplot_heatmap` | `index`, `columns`, `values` | — | `Figure` |
+| `fplot_histogram_kde` | `column` | — | `Figure` |
+| `fplot_pie_donut` | `category`, `value` | — | `Figure` |
+| `fplot_sankey` | `source`, `target`, `value` | — | `Figure` |
+| `fplot_sunburst` | `labels`, `parents`, `values` | — | `Figure` |
+| `fplot_table` | selected `cols` | — | `Figure` |
+| `fplot_timeserie` | `x`, `y` | `label` | `Figure` |
+| `fplot_treemap` | `labels`, `parents`, `values` | — | `Figure` |
+| `fplot_waffle` | `category`, `value` | — | `Figure` |
+| `fplot_wordcloud` | text column | optional weight column | `Figure` |
+
+## Compatibility policy
+
+Parameter renames are not performed silently. A future rename must first add a compatibility alias, emit a `DeprecationWarning`, document the replacement, and remain available until the next major release. Figure helpers must continue returning a `Figure`; callers that need an existing axes should use the corresponding module-level `aplot_*` API where available.

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -7,7 +7,7 @@ This document defines the stable package-root plotting contract for MatplotLibAP
 Every plotting helper exported from `MatplotLibAPI.__all__` follows these rules:
 
 1. Tabular input is named `pd_df` and accepts a pandas `DataFrame`.
-2. Figure helpers are named `fplot_*` and return a Matplotlib `Figure`.
+2. Figure helpers are named `fplot_*` and return an explicit Matplotlib or Plotly `Figure` according to the chart backend.
 3. Existing keyword names remain supported within the current major version.
 4. Shared concepts use the names below when they apply.
 
@@ -29,23 +29,23 @@ Chart-specific structural names such as `source`, `target`, `parents`, `labels`,
 
 ## Package-root signature matrix
 
-| Helper | Primary fields | Optional grouping | Return |
+| Helper | Primary fields | Optional grouping | Backend return |
 | --- | --- | --- | --- |
-| `fplot_area` | `x`, `y` | `label` | `Figure` |
-| `fplot_bar` | `category`, `value` | `group` | `Figure` |
-| `fplot_box_violin` | `column` | `category` | `Figure` |
-| `fplot_correlation_matrix` | numeric DataFrame columns | — | `Figure` |
-| `fplot_heatmap` | `index`, `columns`, `values` | — | `Figure` |
-| `fplot_histogram_kde` | `column` | — | `Figure` |
-| `fplot_pie_donut` | `category`, `value` | — | `Figure` |
-| `fplot_sankey` | `source`, `target`, `value` | — | `Figure` |
-| `fplot_sunburst` | `labels`, `parents`, `values` | — | `Figure` |
-| `fplot_table` | selected `cols` | — | `Figure` |
-| `fplot_timeserie` | `x`, `y` | `label` | `Figure` |
-| `fplot_treemap` | `labels`, `parents`, `values` | — | `Figure` |
-| `fplot_waffle` | `category`, `value` | — | `Figure` |
-| `fplot_wordcloud` | text column | optional weight column | `Figure` |
+| `fplot_area` | `x`, `y` | `label` | Matplotlib `Figure` |
+| `fplot_bar` | `category`, `value` | `group` | Matplotlib `Figure` |
+| `fplot_box_violin` | `column` | `category` | Matplotlib `Figure` |
+| `fplot_correlation_matrix` | numeric DataFrame columns | — | Matplotlib `Figure` |
+| `fplot_heatmap` | `index`, `columns`, `values` | — | Matplotlib `Figure` |
+| `fplot_histogram_kde` | `column` | — | Matplotlib `Figure` |
+| `fplot_pie_donut` | `category`, `value` | — | Matplotlib `Figure` |
+| `fplot_sankey` | `source`, `target`, `value` | — | Plotly `Figure` |
+| `fplot_sunburst` | `labels`, `parents`, `values` | — | Plotly `Figure` |
+| `fplot_table` | selected `cols` | — | Matplotlib `Figure` |
+| `fplot_timeserie` | `x`, `y` | `label` | Matplotlib `Figure` |
+| `fplot_treemap` | `labels`, `parents`, `values` | — | Plotly `Figure` |
+| `fplot_waffle` | `category`, `value` | — | Matplotlib `Figure` |
+| `fplot_wordcloud` | text column | optional weight column | Matplotlib `Figure` |
 
 ## Compatibility policy
 
-Parameter renames are not performed silently. A future rename must first add a compatibility alias, emit a `DeprecationWarning`, document the replacement, and remain available until the next major release. Figure helpers must continue returning a `Figure`; callers that need an existing axes should use the corresponding module-level `aplot_*` API where available.
+Parameter renames are not performed silently. A future rename must first add a compatibility alias, emit a `DeprecationWarning`, document the replacement, and remain available until the next major release. Figure helpers must keep returning their documented backend figure type; callers that need an existing Matplotlib axes should use the corresponding module-level `aplot_*` API where available.

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -3,7 +3,8 @@
 from inspect import Parameter, Signature, signature
 from typing import get_type_hints
 
-from matplotlib.figure import Figure
+from matplotlib.figure import Figure as MatplotlibFigure
+from plotly.graph_objects import Figure as PlotlyFigure
 
 import MatplotLibAPI
 
@@ -13,6 +14,7 @@ PLOT_HELPERS = {
     for name in MatplotLibAPI.__all__
     if name.startswith("fplot_")
 }
+FIGURE_TYPES = {MatplotlibFigure, PlotlyFigure}
 
 
 def test_public_plot_helpers_use_dataframe_first() -> None:
@@ -33,7 +35,7 @@ def test_public_plot_helpers_return_figures() -> None:
     for name, helper in PLOT_HELPERS.items():
         hints = get_type_hints(helper)
 
-        assert hints.get("return") is Figure, f"{name} must return Figure"
+        assert hints.get("return") in FIGURE_TYPES, f"{name} must return a Figure"
 
 
 def test_public_plot_helpers_have_explicit_signatures() -> None:

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -44,6 +44,6 @@ def test_public_plot_helpers_have_explicit_signatures() -> None:
             parameter.kind for parameter in helper_signature.parameters.values()
         }
 
-        assert Parameter.VAR_POSITIONAL not in parameter_kinds, (
-            f"{name} must expose named parameters instead of *args"
-        )
+        assert (
+            Parameter.VAR_POSITIONAL not in parameter_kinds
+        ), f"{name} must expose named parameters instead of *args"

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,0 +1,49 @@
+"""Regression tests for the stable package-root plotting contract."""
+
+from inspect import Parameter, Signature, signature
+from typing import get_type_hints
+
+from matplotlib.figure import Figure
+
+import MatplotLibAPI
+
+
+PLOT_HELPERS = {
+    name: getattr(MatplotLibAPI, name)
+    for name in MatplotLibAPI.__all__
+    if name.startswith("fplot_")
+}
+
+
+def test_public_plot_helpers_use_dataframe_first() -> None:
+    """Require one predictable DataFrame entry point for every figure helper."""
+    for name, helper in PLOT_HELPERS.items():
+        parameters = list(signature(helper).parameters.values())
+
+        assert parameters, f"{name} must accept a DataFrame"
+        assert parameters[0].name == "pd_df", f"{name} must start with pd_df"
+        assert parameters[0].kind in {
+            Parameter.POSITIONAL_ONLY,
+            Parameter.POSITIONAL_OR_KEYWORD,
+        }
+
+
+def test_public_plot_helpers_return_figures() -> None:
+    """Keep the package-root return policy explicit and machine-readable."""
+    for name, helper in PLOT_HELPERS.items():
+        hints = get_type_hints(helper)
+
+        assert hints.get("return") is Figure, f"{name} must return Figure"
+
+
+def test_public_plot_helpers_have_explicit_signatures() -> None:
+    """Prevent generic variadic wrappers from replacing documented APIs."""
+    for name, helper in PLOT_HELPERS.items():
+        helper_signature: Signature = signature(helper)
+        parameter_kinds = {
+            parameter.kind for parameter in helper_signature.parameters.values()
+        }
+
+        assert Parameter.VAR_POSITIONAL not in parameter_kinds, (
+            f"{name} must expose named parameters instead of *args"
+        )


### PR DESCRIPTION
## Summary
- document the canonical package-root plotting vocabulary and signature matrix
- define the stable `pd_df` input and `Figure` return policy
- add regression tests for explicit, machine-readable public signatures
- preserve chart-specific structural names and existing keyword compatibility

Closes #77

## Validation
GitHub Actions must pass Python 3.9–3.12, Black, pydocstyle, Pyright, pytest coverage, and package validation before merge.