### PR TITLE
release: complete roadmap and prepare 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,22 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-- Standardized repository documentation.
+## 4.1.0 - 2026-08-05
+
+### Added
+
+- Explicit, tested package-root public plotting API.
+- Stable plotting parameter and return contracts.
+- Regression coverage for documented imports and signatures.
+- Product, roadmap, contribution, and release documentation.
+
+### Changed
+
+- Aligned README examples with the supported public API.
+- Strengthened CI across Python 3.9–3.12 with formatting, docstring, typing, tests, coverage, and package validation.
+- Standardized repository documentation and release expectations.
+
+### Fixed
+
+- Removed an incompatible redundant pytest docstring plugin.
+- Preserved backward-compatible plotting keyword behavior while locking the supported API.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,17 @@
 # Roadmap
 
-The roadmap is managed through GitHub issues and milestones.
+## Status: complete
 
-Priorities are API consistency, typing, documentation, testing, and stable releases.
+The first-class package roadmap was completed on 2026-08-05 and consolidated in release 4.1.0.
 
-Every item must support `PRODUCT.md`.
+Completed priorities:
+
+- stable and explicit package-root public API
+- consistent plotting parameters and return contracts
+- Python 3.9–3.12 support
+- NumPy-style documentation and current README examples
+- static typing with Pyright
+- automated formatting, tests, coverage, and package validation
+- contribution, changelog, product, and release documentation
+
+Future work is managed as focused GitHub issues. New features must preserve the public API contract, pass the complete quality gate, and support `PRODUCT.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "MatplotLibAPI"
-version = "4.0.5"
+version = "4.1.0"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [


### PR DESCRIPTION
## Summary

- bump the package version from 4.0.5 to 4.1.0
- finalize the changelog for the public API, documentation, testing, and CI work merged since 4.0.5
- mark the first-class package roadmap complete
- move future work to focused compatibility-preserving issues

## Validation

The existing CI quality gate must pass Python 3.9–3.12, Black, pydocstyle, Pyright, pytest coverage, and package validation before merge.