### PR TITLE
ci: validate installed release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,101 @@ jobs:
       - name: Run tests with coverage
         run: python -m pytest -q --cov=src --cov-report=term-missing --cov-fail-under=70
 
-      - name: Build and validate package
-        if: matrix.python-version == '3.12'
+  artifacts:
+    name: Built artifact smoke tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build and validate distributions
         run: |
           python -m build
           python -m twine check dist/*
+
+      - name: Inspect wheel contents
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          wheel = next(Path("dist").glob("*.whl"))
+          with ZipFile(wheel) as archive:
+              names = archive.namelist()
+
+          required = {
+              "MatplotLibAPI/__init__.py",
+              "MatplotLibAPI/py.typed",
+          }
+          missing = sorted(required.difference(names))
+          if missing:
+              raise SystemExit(f"Wheel is missing required files: {missing}")
+
+          forbidden_parts = {"tests", ".pytest_cache", "__pycache__"}
+          unexpected = [
+              name
+              for name in names
+              if any(part in forbidden_parts for part in Path(name).parts)
+          ]
+          if unexpected:
+              raise SystemExit(f"Wheel contains unexpected files: {unexpected}")
+          PY
+
+      - name: Install wheel outside repository checkout
+        run: |
+          python -m venv /tmp/matplotlibapi-wheel
+          /tmp/matplotlibapi-wheel/bin/python -m pip install --upgrade pip
+          /tmp/matplotlibapi-wheel/bin/python -m pip install dist/*.whl
+
+      - name: Smoke test installed public API and plotting
+        working-directory: /tmp
+        env:
+          MPLBACKEND: Agg
+        run: |
+          /tmp/matplotlibapi-wheel/bin/python - <<'PY'
+          import pandas as pd
+          from matplotlib.figure import Figure
+          import MatplotLibAPI as api
+
+          missing = [name for name in api.__all__ if not hasattr(api, name)]
+          if missing:
+              raise SystemExit(f"Missing package-root exports: {missing}")
+
+          frame = pd.DataFrame(
+              {
+                  "category": ["alpha", "beta", "gamma"],
+                  "value": [1, 3, 2],
+              }
+          )
+          figure = api.fplot_bar(
+              pd_df=frame,
+              category="category",
+              value="value",
+              title="artifact smoke test",
+          )
+          if not isinstance(figure, Figure):
+              raise SystemExit(
+                  f"fplot_bar returned {type(figure)!r}, expected Figure"
+              )
+          figure.savefig("matplotlibapi-artifact-smoke.png")
+          PY
+
+      - name: Test source distribution installation
+        run: |
+          python -m venv /tmp/matplotlibapi-sdist
+          /tmp/matplotlibapi-sdist/bin/python -m pip install --upgrade pip
+          /tmp/matplotlibapi-sdist/bin/python -m pip install dist/*.tar.gz
+          cd /tmp
+          /tmp/matplotlibapi-sdist/bin/python -c "import MatplotLibAPI; assert MatplotLibAPI.__all__"


### PR DESCRIPTION
## Summary

- split package artifact validation into a dedicated CI job
- build and validate both wheel and source distribution
- inspect wheel contents for required and forbidden files
- install artifacts into clean virtual environments outside the checkout
- import every supported package-root export from the installed wheel
- render and save a representative headless bar plot
- add the PEP 561 `py.typed` marker for downstream type checkers

Closes #87.

## Validation

GitHub Actions must pass the Python 3.9–3.12 quality matrix and the new installed-artifact smoke-test job before merge.