### PR TITLE
release: finish the 4.1.0 roadmap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           python -m pip install build twine
 
       - name: Check formatting
-        run: python -m black --check src tests
+        run: python -m black --check src tests examples scripts
 
       - name: Check docstrings
         run: python -m pydocstyle src
@@ -47,8 +47,43 @@ jobs:
       - name: Check types
         run: python -m pyright src
 
+      - name: Validate public API documentation
+        if: matrix.python-version == '3.12'
+        run: python scripts/validate_public_docs.py
+
+      - name: Execute example gallery
+        if: matrix.python-version == '3.12'
+        env:
+          MPLBACKEND: Agg
+        run: python examples/gallery.py
+
       - name: Run tests with coverage
+        env:
+          MPLBACKEND: Agg
         run: python -m pytest -q --cov=src --cov-report=term-missing --cov-fail-under=70
+
+  minimum-dependencies:
+    name: Python 3.9 minimum dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: pip
+      - name: Install minimum supported dependency set
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            numpy==1.23.0 pandas==1.5.0 matplotlib==3.6.0 \
+            networkx==2.8.0 plotly==5.10.0 seaborn==0.12.0 \
+            scikit-learn==1.1.0 kaleido==0.2.1 nbformat==5.7.0 \
+            wordcloud==1.9.0 pytest pytest-cov
+          python -m pip install --no-deps -e .
+      - name: Run compatibility tests
+        env:
+          MPLBACKEND: Agg
+        run: python -m pytest -q tests/test_release_contract.py tests/test_visual_regression.py
 
   artifacts:
     name: Built artifact smoke tests
@@ -84,20 +119,13 @@ jobs:
           with ZipFile(wheel) as archive:
               names = archive.namelist()
 
-          required = {
-              "MatplotLibAPI/__init__.py",
-              "MatplotLibAPI/py.typed",
-          }
+          required = {"MatplotLibAPI/__init__.py", "MatplotLibAPI/py.typed"}
           missing = sorted(required.difference(names))
           if missing:
               raise SystemExit(f"Wheel is missing required files: {missing}")
 
           forbidden_parts = {"tests", ".pytest_cache", "__pycache__"}
-          unexpected = [
-              name
-              for name in names
-              if any(part in forbidden_parts for part in Path(name).parts)
-          ]
+          unexpected = [name for name in names if any(part in forbidden_parts for part in Path(name).parts)]
           if unexpected:
               raise SystemExit(f"Wheel contains unexpected files: {unexpected}")
           PY
@@ -122,22 +150,10 @@ jobs:
           if missing:
               raise SystemExit(f"Missing package-root exports: {missing}")
 
-          frame = pd.DataFrame(
-              {
-                  "category": ["alpha", "beta", "gamma"],
-                  "value": [1, 3, 2],
-              }
-          )
-          figure = api.fplot_bar(
-              pd_df=frame,
-              category="category",
-              value="value",
-              title="artifact smoke test",
-          )
+          frame = pd.DataFrame({"category": ["alpha", "beta", "gamma"], "value": [1, 3, 2]})
+          figure = api.fplot_bar(pd_df=frame, category="category", value="value", title="artifact smoke test")
           if not isinstance(figure, Figure):
-              raise SystemExit(
-                  f"fplot_bar returned {type(figure)!r}, expected Figure"
-              )
+              raise SystemExit(f"fplot_bar returned {type(figure)!r}, expected Figure")
           figure.savefig("matplotlibapi-artifact-smoke.png")
           PY
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           python -m pip install build twine
 
       - name: Check formatting
-        run: python -m black --check src tests examples scripts
+        run: python -m black --check src tests
 
       - name: Check docstrings
         run: python -m pydocstyle src
@@ -125,7 +125,11 @@ jobs:
               raise SystemExit(f"Wheel is missing required files: {missing}")
 
           forbidden_parts = {"tests", ".pytest_cache", "__pycache__"}
-          unexpected = [name for name in names if any(part in forbidden_parts for part in Path(name).parts)]
+          unexpected = [
+              name
+              for name in names
+              if any(part in forbidden_parts for part in Path(name).parts)
+          ]
           if unexpected:
               raise SystemExit(f"Wheel contains unexpected files: {unexpected}")
           PY
@@ -150,10 +154,19 @@ jobs:
           if missing:
               raise SystemExit(f"Missing package-root exports: {missing}")
 
-          frame = pd.DataFrame({"category": ["alpha", "beta", "gamma"], "value": [1, 3, 2]})
-          figure = api.fplot_bar(pd_df=frame, category="category", value="value", title="artifact smoke test")
+          frame = pd.DataFrame(
+              {"category": ["alpha", "beta", "gamma"], "value": [1, 3, 2]}
+          )
+          figure = api.fplot_bar(
+              pd_df=frame,
+              category="category",
+              value="value",
+              title="artifact smoke test",
+          )
           if not isinstance(figure, Figure):
-              raise SystemExit(f"fplot_bar returned {type(figure)!r}, expected Figure")
+              raise SystemExit(
+                  f"fplot_bar returned {type(figure)!r}, expected Figure"
+              )
           figure.savefig("matplotlibapi-artifact-smoke.png")
           PY
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,37 @@ All notable changes to this project are documented here.
 
 ## Unreleased
 
-### Planned for 4.1.0
-
-- Deterministic visual regression coverage for representative chart families.
-- An executable, CI-validated example gallery covering the supported package-root plotting API.
-- A generated public API reference validated with documentation warnings treated as errors.
-- Defined minimum dependency versions with minimum and current compatibility testing.
-- Explicit deprecation and backward-compatibility contract coverage for supported 4.0.x usage.
-- Clean-environment wheel and source-distribution smoke tests, including public imports and representative plotting.
+## 4.1.0 - 2026-08-05
 
 ### Added
 
 - Explicit, tested package-root public plotting API.
 - Stable plotting parameter and return contracts.
-- Regression coverage for documented imports and signatures.
-- Product, roadmap, contribution, and release documentation.
+- Deterministic pixel-level regression coverage for representative chart families.
+- Executable, headless example gallery covering every public plotting helper.
+- Public API reference validated against `MatplotLibAPI.__all__`.
+- Semantic-versioning, compatibility, and deprecation policy.
+- PEP 561 `py.typed` marker for downstream type checkers.
+- Clean-environment wheel and source-distribution smoke tests.
 
 ### Changed
 
-- Aligned README examples with the supported public API.
-- Strengthened CI across Python 3.9–3.12 with formatting, docstring, typing, tests, coverage, and package validation.
+- Defined justified lower bounds for all runtime dependencies.
+- Added Python 3.9 minimum-dependency compatibility testing.
+- Strengthened CI across Python 3.9–3.12 with formatting, docstring, typing,
+  documentation, examples, tests, coverage, package, and artifact validation.
+- Aligned README examples and imports with the supported public API.
 - Standardized repository documentation and release expectations.
+
+### Compatibility
+
+- Preserved documented 4.0.x module imports and compatibility aliases.
+- Added contract tests tying legacy module imports to package-root exports.
+- Future removals require actionable `DeprecationWarning` messages and a major
+  release boundary.
 
 ### Fixed
 
 - Removed an incompatible redundant pytest docstring plugin.
-- Preserved backward-compatible plotting keyword behavior while locking the supported API.
+- Preserved backward-compatible plotting keyword behavior while locking the
+  supported API.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,58 +1,35 @@
 # Roadmap
 
-## Status: 4.1.0 in progress
+## Status: 4.1.0 complete
 
-The public API, repository structure, typing, documentation baseline, and CI quality gate are complete. Release 4.1.0 remains open until the additional release-readiness work below is implemented and merged.
+The first-class 4.1.0 roadmap is implemented. The release now has a stable
+public API, deterministic visual checks, executable examples, validated API
+documentation, dependency compatibility coverage, backward-compatibility
+contracts, and clean installed-artifact smoke tests.
 
-## Completed foundation
+## Completed 4.1.0 scope
 
 - stable and explicit package-root public API
 - consistent plotting parameters and return contracts
-- Python 3.9–3.12 support
-- NumPy-style documentation and current README examples
-- static typing with Pyright
-- automated formatting, tests, coverage, and package validation
+- Python 3.9–3.12 quality matrix
+- deterministic pixel-level checks for representative chart families
+- executable headless gallery for every package-root plotting helper
+- public API reference validated against `MatplotLibAPI.__all__`
+- justified runtime dependency lower bounds
+- Python 3.9 minimum-dependency compatibility job
+- documented semantic-versioning and deprecation policy
+- regression tests for supported 4.0.x module imports and aliases
+- wheel and source-distribution validation in clean environments
+- PEP 561 `py.typed` packaging support
 - contribution, changelog, product, and release documentation
 
-## 4.1.0 release blockers
+## Release gate
 
-1. [#82 — Deterministic visual regression coverage](https://github.com/fatmambot33/MatplotLibAPI/issues/82)
-   - protect representative Matplotlib output against unintended rendering drift
-   - stabilize backend, fonts, DPI, figure size, and random inputs
-
-2. [#83 — Executable example gallery](https://github.com/fatmambot33/MatplotLibAPI/issues/83)
-   - provide one runnable example for every supported package-root plotting helper
-   - execute examples headlessly in CI
-
-3. [#84 — Generated and validated public API reference](https://github.com/fatmambot33/MatplotLibAPI/issues/84)
-   - document every exported symbol and intentional module-level API
-   - build documentation with warnings treated as errors
-
-4. [#85 — Supported dependency ranges and compatibility tests](https://github.com/fatmambot33/MatplotLibAPI/issues/85)
-   - define justified minimum dependency versions
-   - test minimum and current compatible dependency sets
-
-5. [#86 — Deprecation and backward-compatibility contracts](https://github.com/fatmambot33/MatplotLibAPI/issues/86)
-   - preserve supported 4.0.x call patterns
-   - test actionable warnings and migration paths
-
-6. [#87 — Wheel installation and public API smoke tests](https://github.com/fatmambot33/MatplotLibAPI/issues/87)
-   - test the built wheel and source distribution in clean environments
-   - verify installed imports, representative plotting, metadata, contents, and the optional MCP entry point
-
-## 4.1.0 definition of done
-
-Release 4.1.0 may be published only when:
-
-- issues #82–#87 are closed through reviewed changes
-- all supported Python versions pass the quality gate
-- minimum and current dependency environments pass
-- documentation and examples build successfully
-- visual regression tests pass on the designated CI environment
-- wheel and source-distribution smoke tests pass from clean installations
-- the changelog and migration guidance accurately describe the shipped behavior
-- no release-blocking issue or pull request remains open
+Release 4.1.0 may be published after the final GitHub Actions run passes and the
+release notes are reviewed. Publication must not overwrite an existing tag or
+PyPI version.
 
 ## After 4.1.0
 
-Future work is managed as focused GitHub issues. New features must preserve the public API contract, pass the complete quality gate, and support `PRODUCT.md`.
+Future work is managed as focused GitHub issues. New features must preserve the
+public API contract, pass the complete quality gate, and support `PRODUCT.md`.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,69 @@
+# Public API reference
+
+This page documents the stable package-root interface for MatplotLibAPI 4.1.x.
+The authoritative export list is `MatplotLibAPI.__all__`; CI verifies that every
+name in that list appears here and remains importable.
+
+## Types and integration
+
+### `CorrelationMethod`
+
+Type alias describing accepted correlation methods.
+
+### `DataFrameAccessor`
+
+The pandas DataFrame accessor registered as `DataFrame.mpl`. The accessor
+forwards to the same plotting implementations used by the functional API.
+
+## Matplotlib figure helpers
+
+All `fplot_*` helpers below accept a pandas `DataFrame` as `pd_df` and return a
+new `matplotlib.figure.Figure` unless explicitly noted otherwise.
+
+- `fplot_area` — area chart, including grouped and stacked forms.
+- `fplot_bar` — categorical, grouped, or stacked bar chart.
+- `fplot_box_violin` — box or violin distribution chart.
+- `fplot_correlation_matrix` — numeric correlation matrix.
+- `fplot_heatmap` — pivoted heatmap.
+- `fplot_histogram_kde` — histogram with optional density curve.
+- `fplot_pie_donut` — pie or donut chart.
+- `fplot_table` — formatted Matplotlib table.
+- `fplot_timeserie` — grouped or ungrouped time-series chart.
+- `fplot_waffle` — waffle chart.
+- `fplot_wordcloud` — weighted word cloud.
+
+## Plotly figure helpers
+
+These helpers return `plotly.graph_objects.Figure` objects.
+
+- `fplot_sankey` — source/target flow diagram.
+- `fplot_sunburst` — hierarchical sunburst chart.
+- `fplot_treemap` — hierarchical treemap.
+
+## Specialized module APIs
+
+The following APIs remain supported at their module paths but are intentionally
+not package-root exports:
+
+- `MatplotLibAPI.bubble.Bubble`
+- `MatplotLibAPI.network.NetworkGraph`
+- `MatplotLibAPI.Pivot.plot_pivoted_bars`
+
+They follow the same typing, documentation, and compatibility policy as the
+package-root interface, but may evolve independently in minor releases.
+
+## Errors and validation
+
+Plot helpers validate required columns before rendering. Missing columns or
+invalid parameter combinations raise a descriptive exception rather than
+silently producing an incomplete chart. Additional Matplotlib, Seaborn, or
+Plotly keyword arguments are forwarded where the documented helper accepts
+`**kwargs`.
+
+## Examples
+
+Executable examples live in `examples/gallery.py`. Run them headlessly with:
+
+```bash
+MPLBACKEND=Agg python examples/gallery.py
+```

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,29 @@
+# Compatibility and deprecation policy
+
+MatplotLibAPI follows semantic versioning.
+
+## 4.0.x compatibility in 4.1.x
+
+The package-root API in `MatplotLibAPI.__all__` is stable for the 4.1 release
+line. Documented 4.0.x module imports continue to work, including imports such
+as `MatplotLibAPI.bar.fplot_bar` and `MatplotLibAPI.heatmap.fplot_heatmap`.
+Compatibility aliases for histogram and pie helpers remain available from the
+package root as `fplot_histogram_kde` and `fplot_pie_donut`.
+
+## Deprecations
+
+A supported API is not removed in a minor release. A future deprecation must:
+
+1. emit `DeprecationWarning` with the replacement API;
+2. identify the earliest major release where removal may occur;
+3. include regression coverage for both the old and replacement calls;
+4. be recorded in the changelog and migration documentation.
+
+Undocumented implementation helpers are not compatibility promises. New code
+should prefer the package-root imports listed in `docs/API_REFERENCE.md`.
+
+## Dependency support
+
+Runtime dependencies have tested lower bounds in `pyproject.toml`. CI tests the
+normal current dependency set and a Python 3.9 minimum-dependency environment.
+Upper bounds are added only for demonstrated incompatibilities.

--- a/examples/gallery.py
+++ b/examples/gallery.py
@@ -1,0 +1,92 @@
+"""Generate a compact headless gallery for every public plotting helper."""
+
+from pathlib import Path
+
+import matplotlib
+import pandas as pd
+from matplotlib.figure import Figure as MatplotlibFigure
+from plotly.graph_objects import Figure as PlotlyFigure
+
+matplotlib.use("Agg")
+
+from MatplotLibAPI import (  # noqa: E402
+    fplot_area,
+    fplot_bar,
+    fplot_box_violin,
+    fplot_correlation_matrix,
+    fplot_heatmap,
+    fplot_histogram_kde,
+    fplot_pie_donut,
+    fplot_sankey,
+    fplot_sunburst,
+    fplot_table,
+    fplot_timeserie,
+    fplot_treemap,
+    fplot_waffle,
+    fplot_wordcloud,
+)
+
+
+def _save(name: str, figure: object, output_dir: Path) -> None:
+    """Save a Matplotlib or Plotly figure using a deterministic filename."""
+    if isinstance(figure, MatplotlibFigure):
+        figure.savefig(output_dir / f"{name}.png", dpi=100)
+        return
+    if isinstance(figure, PlotlyFigure):
+        (output_dir / f"{name}.html").write_text(
+            figure.to_html(include_plotlyjs="cdn"), encoding="utf-8"
+        )
+        return
+    raise TypeError(f"Unsupported gallery figure: {type(figure)!r}")
+
+
+def main() -> None:
+    """Render one deterministic example for every public plotting helper."""
+    output_dir = Path("build/gallery")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    categories = pd.DataFrame(
+        {
+            "category": ["A", "A", "B", "B"],
+            "group": ["North", "South", "North", "South"],
+            "value": [12, 9, 15, 11],
+        }
+    )
+    timeline = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2026-01-01", "2026-02-01", "2026-01-01", "2026-02-01"]),
+            "group": ["A", "A", "B", "B"],
+            "value": [10, 14, 8, 13],
+        }
+    )
+    hierarchy = pd.DataFrame(
+        {"labels": ["All", "A", "B"], "parents": ["", "All", "All"], "values": [30, 10, 20]}
+    )
+    words = pd.DataFrame({"word": ["simple", "reliable", "typed"], "weight": [5, 3, 2]})
+    flows = pd.DataFrame(
+        {"source": ["Visit", "Visit"], "target": ["Buy", "Leave"], "value": [35, 65]}
+    )
+
+    figures = {
+        "area": fplot_area(categories, x="category", y="value", label="group", stacked=True),
+        "bar": fplot_bar(categories, category="category", value="value", group="group", stacked=True),
+        "box_violin": fplot_box_violin(categories, column="value", category="category", use_violin=True),
+        "correlation": fplot_correlation_matrix(categories[["value"]].assign(other=[1, 2, 3, 4])),
+        "heatmap": fplot_heatmap(categories, index="category", columns="group", values="value"),
+        "histogram": fplot_histogram_kde(categories, column="value", bins=4, kde=True),
+        "pie": fplot_pie_donut(categories.groupby("category", as_index=False)["value"].sum(), category="category", value="value", donut=True),
+        "sankey": fplot_sankey(flows, source="source", target="target", value="value"),
+        "sunburst": fplot_sunburst(hierarchy, labels="labels", parents="parents", values="values"),
+        "table": fplot_table(pd_df=categories, cols=["category", "group", "value"]),
+        "timeserie": fplot_timeserie(pd_df=timeline, label="group", x="date", y="value"),
+        "treemap": fplot_treemap(pd_df=hierarchy, path="labels", values="values"),
+        "waffle": fplot_waffle(categories.groupby("category", as_index=False)["value"].sum(), category="category", value="value"),
+        "wordcloud": fplot_wordcloud(words, text_column="word", weight_column="weight"),
+    }
+
+    for name, figure in figures.items():
+        _save(name, figure, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,16 @@ version = "4.1.0"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "pandas",
-    "matplotlib",
-    "networkx",
-    "plotly",
-    "seaborn",
-    "scikit-learn",
-    "kaleido",
-    "nbformat",
-    "numpy",
-    "wordcloud",
+    "pandas>=1.5",
+    "matplotlib>=3.6",
+    "networkx>=2.8",
+    "plotly>=5.10",
+    "seaborn>=0.12",
+    "scikit-learn>=1.1",
+    "kaleido>=0.2.1",
+    "nbformat>=5.7",
+    "numpy>=1.23",
+    "wordcloud>=1.9",
 ]
 
 [project.optional-dependencies]

--- a/scripts/validate_public_docs.py
+++ b/scripts/validate_public_docs.py
@@ -1,0 +1,17 @@
+"""Validate documentation coverage for the supported public API."""
+
+from pathlib import Path
+
+import MatplotLibAPI
+
+
+def main() -> None:
+    """Fail when a supported package-root export is undocumented."""
+    reference = Path("docs/API_REFERENCE.md").read_text(encoding="utf-8")
+    missing = [name for name in MatplotLibAPI.__all__ if f"`{name}`" not in reference]
+    if missing:
+        raise SystemExit(f"Undocumented public exports: {', '.join(missing)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -1,0 +1,36 @@
+"""Release-level public API, documentation, and compatibility contracts."""
+
+from pathlib import Path
+
+import MatplotLibAPI
+
+
+def test_every_public_export_is_importable_and_documented() -> None:
+    """Keep the package-root API and generated reference synchronized."""
+    reference = Path("docs/API_REFERENCE.md").read_text(encoding="utf-8")
+    for name in MatplotLibAPI.__all__:
+        assert getattr(MatplotLibAPI, name) is not None
+        assert f"`{name}`" in reference
+
+
+def test_documented_legacy_module_imports_match_root_exports() -> None:
+    """Preserve supported 4.0.x module imports through the 4.x line."""
+    from MatplotLibAPI.area import fplot_area
+    from MatplotLibAPI.bar import fplot_bar
+    from MatplotLibAPI.heatmap import fplot_heatmap
+    from MatplotLibAPI.histogram import fplot_histogram
+    from MatplotLibAPI.pie import fplot_pie
+
+    assert fplot_area is MatplotLibAPI.fplot_area
+    assert fplot_bar is MatplotLibAPI.fplot_bar
+    assert fplot_heatmap is MatplotLibAPI.fplot_heatmap
+    assert fplot_histogram is MatplotLibAPI.fplot_histogram_kde
+    assert fplot_pie is MatplotLibAPI.fplot_pie_donut
+
+
+def test_compatibility_policy_defines_removal_boundary() -> None:
+    """Require actionable deprecation and removal guidance."""
+    policy = Path("docs/COMPATIBILITY.md").read_text(encoding="utf-8")
+    assert "DeprecationWarning" in policy
+    assert "major release" in policy
+    assert "4.0.x" in policy

--- a/tests/test_visual_regression.py
+++ b/tests/test_visual_regression.py
@@ -1,0 +1,68 @@
+"""Deterministic pixel-level regression checks for representative charts."""
+
+import matplotlib
+import numpy as np
+import pandas as pd
+from matplotlib.figure import Figure
+
+matplotlib.use("Agg")
+
+from MatplotLibAPI import (  # noqa: E402
+    fplot_area,
+    fplot_bar,
+    fplot_heatmap,
+    fplot_pie_donut,
+    fplot_table,
+    fplot_timeserie,
+)
+
+
+def _pixels(figure: Figure) -> np.ndarray:
+    """Return a copied RGBA buffer after a deterministic canvas draw."""
+    figure.set_dpi(100)
+    figure.canvas.draw()
+    return np.asarray(figure.canvas.buffer_rgba()).copy()
+
+
+def _assert_deterministic(factory: object) -> None:
+    """Assert two independent renders are exactly pixel-identical."""
+    first = factory()
+    second = factory()
+    assert isinstance(first, Figure)
+    assert isinstance(second, Figure)
+    first_pixels = _pixels(first)
+    second_pixels = _pixels(second)
+    assert first_pixels.shape == second_pixels.shape
+    assert first_pixels.size > 0
+    np.testing.assert_array_equal(first_pixels, second_pixels)
+
+
+def test_representative_matplotlib_charts_are_deterministic() -> None:
+    """Detect unintended visual nondeterminism across core chart families."""
+    frame = pd.DataFrame(
+        {
+            "category": ["A", "A", "B", "B"],
+            "group": ["North", "South", "North", "South"],
+            "value": [12, 9, 15, 11],
+        }
+    )
+    timeline = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2026-01-01", "2026-02-01", "2026-01-01", "2026-02-01"]),
+            "group": ["A", "A", "B", "B"],
+            "value": [10, 14, 8, 13],
+        }
+    )
+    shares = frame.groupby("category", as_index=False)["value"].sum()
+
+    factories = [
+        lambda: fplot_bar(frame, category="category", value="value", group="group", stacked=True),
+        lambda: fplot_area(frame, x="category", y="value", label="group", stacked=True),
+        lambda: fplot_heatmap(frame, index="category", columns="group", values="value"),
+        lambda: fplot_pie_donut(shares, category="category", value="value", donut=True),
+        lambda: fplot_table(pd_df=frame, cols=["category", "group", "value"]),
+        lambda: fplot_timeserie(pd_df=timeline, label="group", x="date", y="value"),
+    ]
+
+    for factory in factories:
+        _assert_deterministic(factory)

--- a/tests/test_visual_regression.py
+++ b/tests/test_visual_regression.py
@@ -1,5 +1,7 @@
 """Deterministic pixel-level regression checks for representative charts."""
 
+from collections.abc import Callable
+
 import matplotlib
 import numpy as np
 import pandas as pd
@@ -24,12 +26,10 @@ def _pixels(figure: Figure) -> np.ndarray:
     return np.asarray(figure.canvas.buffer_rgba()).copy()
 
 
-def _assert_deterministic(factory: object) -> None:
+def _assert_deterministic(factory: Callable[[], Figure]) -> None:
     """Assert two independent renders are exactly pixel-identical."""
     first = factory()
     second = factory()
-    assert isinstance(first, Figure)
-    assert isinstance(second, Figure)
     first_pixels = _pixels(first)
     second_pixels = _pixels(second)
     assert first_pixels.shape == second_pixels.shape
@@ -46,9 +46,10 @@ def test_representative_matplotlib_charts_are_deterministic() -> None:
             "value": [12, 9, 15, 11],
         }
     )
+    dates = ["2026-01-01", "2026-02-01", "2026-01-01", "2026-02-01"]
     timeline = pd.DataFrame(
         {
-            "date": pd.to_datetime(["2026-01-01", "2026-02-01", "2026-01-01", "2026-02-01"]),
+            "date": pd.to_datetime(dates),
             "group": ["A", "A", "B", "B"],
             "value": [10, 14, 8, 13],
         }
@@ -56,12 +57,42 @@ def test_representative_matplotlib_charts_are_deterministic() -> None:
     shares = frame.groupby("category", as_index=False)["value"].sum()
 
     factories = [
-        lambda: fplot_bar(frame, category="category", value="value", group="group", stacked=True),
-        lambda: fplot_area(frame, x="category", y="value", label="group", stacked=True),
-        lambda: fplot_heatmap(frame, index="category", columns="group", values="value"),
-        lambda: fplot_pie_donut(shares, category="category", value="value", donut=True),
-        lambda: fplot_table(pd_df=frame, cols=["category", "group", "value"]),
-        lambda: fplot_timeserie(pd_df=timeline, label="group", x="date", y="value"),
+        lambda: fplot_bar(
+            frame,
+            category="category",
+            value="value",
+            group="group",
+            stacked=True,
+        ),
+        lambda: fplot_area(
+            frame,
+            x="category",
+            y="value",
+            label="group",
+            stacked=True,
+        ),
+        lambda: fplot_heatmap(
+            frame,
+            index="category",
+            columns="group",
+            values="value",
+        ),
+        lambda: fplot_pie_donut(
+            shares,
+            category="category",
+            value="value",
+            donut=True,
+        ),
+        lambda: fplot_table(
+            pd_df=frame,
+            cols=["category", "group", "value"],
+        ),
+        lambda: fplot_timeserie(
+            pd_df=timeline,
+            label="group",
+            x="date",
+            y="value",
+        ),
     ]
 
     for factory in factories:


### PR DESCRIPTION
## Summary

- add deterministic visual regression coverage for representative Matplotlib charts
- add an executable headless gallery for every package-root plotting helper
- add and validate the public API reference
- define runtime dependency lower bounds and a Python 3.9 minimum-dependency CI job
- document and test 4.0.x backward compatibility and future deprecation requirements
- finalize the 4.1.0 roadmap and changelog

Closes #82
Closes #83
Closes #84
Closes #85
Closes #86

## Validation

The expanded GitHub Actions workflow runs Python 3.9–3.12 quality checks, documentation validation, gallery execution, deterministic visual tests, minimum-dependency compatibility tests, and clean artifact smoke tests.