### PR TITLE
feat: add first-class plugin surface

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -15,6 +15,22 @@ Type alias describing accepted correlation methods.
 The pandas DataFrame accessor registered as `DataFrame.mpl`. The accessor
 forwards to the same plotting implementations used by the functional API.
 
+## Plugin surface
+
+The plugin API is framework-neutral and versioned independently from the
+package release.
+
+- `PLUGIN_API_VERSION` — current plugin contract version.
+- `Plugin` — typed protocol requiring a name, API version, and setup method.
+- `PluginContext` — registration context used to expose named plot callables.
+- `PluginRegistry` — deterministic registry for built-in and installed plugins.
+- `CorePlotsPlugin` — built-in plugin exposing the stable plotting helpers.
+- `create_registry` — creates a core registry and optionally discovers installed
+  plugins from the `matplotlibapi.plugins` entry-point group.
+
+Plugin setup is atomic. Failed setup does not leave partially registered plots,
+and duplicate plugin or plot names are rejected.
+
 ## Matplotlib figure helpers
 
 All `fplot_*` helpers below accept a pandas `DataFrame` as `pd_df` and return a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "wordcloud>=1.9.1.1",
 ]
 
+[project.entry-points."matplotlibapi.plugins"]
+core = "MatplotLibAPI.plugins:CorePlotsPlugin"
+
 [project.optional-dependencies]
 dev = [
     "pydocstyle",

--- a/src/MatplotLibAPI/__init__.py
+++ b/src/MatplotLibAPI/__init__.py
@@ -11,6 +11,14 @@ from .box_violin import fplot_box_violin
 from .heatmap import fplot_correlation_matrix, fplot_heatmap
 from .histogram import fplot_histogram as fplot_histogram_kde
 from .pie import fplot_pie as fplot_pie_donut
+from .plugins import (
+    PLUGIN_API_VERSION,
+    CorePlotsPlugin,
+    Plugin,
+    PluginContext,
+    PluginRegistry,
+    create_registry,
+)
 from .sankey import fplot_sankey
 from .sunburst import fplot_sunburst
 from .table import fplot_table
@@ -21,8 +29,14 @@ from .waffle import fplot_waffle
 from .word_cloud import fplot_wordcloud
 
 __all__ = [
+    "PLUGIN_API_VERSION",
+    "CorePlotsPlugin",
     "CorrelationMethod",
     "DataFrameAccessor",
+    "Plugin",
+    "PluginContext",
+    "PluginRegistry",
+    "create_registry",
     "fplot_area",
     "fplot_bar",
     "fplot_box_violin",

--- a/src/MatplotLibAPI/plugins.py
+++ b/src/MatplotLibAPI/plugins.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from importlib import metadata
-from typing import Any, Callable, Dict, Iterable, List, Protocol, runtime_checkable
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Protocol,
+    cast,
+    runtime_checkable,
+)
 
 PLUGIN_API_VERSION = "1"
 ENTRY_POINT_GROUP = "matplotlibapi.plugins"
@@ -97,7 +107,11 @@ class PluginRegistry:
                 group=ENTRY_POINT_GROUP
             )
         else:  # pragma: no cover - Python 3.9 compatibility
-            entries = discovered.get(ENTRY_POINT_GROUP, [])
+            legacy = cast(
+                Mapping[str, Iterable[metadata.EntryPoint]],
+                discovered,
+            )
+            entries = legacy.get(ENTRY_POINT_GROUP, ())
         for entry in sorted(entries, key=lambda item: item.name):
             plugin_factory = entry.load()
             self.register(plugin_factory())

--- a/src/MatplotLibAPI/plugins.py
+++ b/src/MatplotLibAPI/plugins.py
@@ -1,0 +1,174 @@
+"""Typed plugin discovery and registration for MatplotLibAPI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib import metadata
+from typing import Any, Callable, Dict, Iterable, List, Protocol, runtime_checkable
+
+PLUGIN_API_VERSION = "1"
+ENTRY_POINT_GROUP = "matplotlibapi.plugins"
+PlotCallable = Callable[..., Any]
+
+
+class PluginError(RuntimeError):
+    """Base error raised by the plugin surface."""
+
+
+class DuplicatePluginError(PluginError):
+    """Raised when a plugin or plot name is registered twice."""
+
+
+@runtime_checkable
+class Plugin(Protocol):
+    """Minimal contract implemented by MatplotLibAPI plugins."""
+
+    name: str
+    api_version: str
+
+    def setup(self, context: "PluginContext") -> None:
+        """Register plotting functions in ``context``."""
+
+
+@dataclass
+class PluginContext:
+    """Registration context passed to plugins."""
+
+    _plots: Dict[str, PlotCallable] = field(default_factory=dict)
+
+    def register_plot(self, name: str, function: PlotCallable) -> None:
+        """Register one named plotting callable.
+
+        Parameters
+        ----------
+        name:
+            Stable public plot name.
+        function:
+            Callable implementing the plot.
+        """
+        if not name or name in self._plots:
+            raise DuplicatePluginError(f"Plot already registered: {name!r}")
+        self._plots[name] = function
+
+    def get_plot(self, name: str) -> PlotCallable:
+        """Return a registered plot callable by name."""
+        try:
+            return self._plots[name]
+        except KeyError as exc:
+            raise PluginError(f"Unknown plot: {name!r}") from exc
+
+    def list_plots(self) -> List[str]:
+        """Return registered plot names in deterministic order."""
+        return sorted(self._plots)
+
+
+class PluginRegistry:
+    """Load, validate, and expose MatplotLibAPI plugins."""
+
+    def __init__(self) -> None:
+        self.context = PluginContext()
+        self._plugins: Dict[str, Plugin] = {}
+
+    def register(self, plugin: Plugin) -> None:
+        """Register one plugin atomically."""
+        if not isinstance(plugin, Plugin):
+            raise PluginError("Plugin does not implement the required contract")
+        if plugin.api_version != PLUGIN_API_VERSION:
+            raise PluginError(
+                f"Unsupported plugin API {plugin.api_version!r}; "
+                f"expected {PLUGIN_API_VERSION!r}"
+            )
+        if plugin.name in self._plugins:
+            raise DuplicatePluginError(f"Plugin already registered: {plugin.name!r}")
+
+        previous = dict(self.context._plots)
+        try:
+            plugin.setup(self.context)
+        except Exception:
+            self.context._plots = previous
+            raise
+        self._plugins[plugin.name] = plugin
+
+    def discover(self) -> None:
+        """Load plugins installed through Python entry points."""
+        discovered = metadata.entry_points()
+        if hasattr(discovered, "select"):
+            entries: Iterable[metadata.EntryPoint] = discovered.select(
+                group=ENTRY_POINT_GROUP
+            )
+        else:  # pragma: no cover - Python 3.9 compatibility
+            entries = discovered.get(ENTRY_POINT_GROUP, [])
+        for entry in sorted(entries, key=lambda item: item.name):
+            plugin_factory = entry.load()
+            self.register(plugin_factory())
+
+    def list_plugins(self) -> List[str]:
+        """Return registered plugin names in deterministic order."""
+        return sorted(self._plugins)
+
+
+class CorePlotsPlugin:
+    """Built-in plugin exposing the stable package plotting API."""
+
+    name = "core"
+    api_version = PLUGIN_API_VERSION
+
+    def setup(self, context: PluginContext) -> None:
+        """Register stable package-root plotting functions."""
+        from . import (
+            fplot_area,
+            fplot_bar,
+            fplot_box_violin,
+            fplot_correlation_matrix,
+            fplot_heatmap,
+            fplot_histogram_kde,
+            fplot_pie_donut,
+            fplot_sankey,
+            fplot_sunburst,
+            fplot_table,
+            fplot_timeserie,
+            fplot_treemap,
+            fplot_waffle,
+            fplot_wordcloud,
+        )
+
+        plots = {
+            "area": fplot_area,
+            "bar": fplot_bar,
+            "box_violin": fplot_box_violin,
+            "correlation_matrix": fplot_correlation_matrix,
+            "heatmap": fplot_heatmap,
+            "histogram_kde": fplot_histogram_kde,
+            "pie_donut": fplot_pie_donut,
+            "sankey": fplot_sankey,
+            "sunburst": fplot_sunburst,
+            "table": fplot_table,
+            "timeserie": fplot_timeserie,
+            "treemap": fplot_treemap,
+            "waffle": fplot_waffle,
+            "wordcloud": fplot_wordcloud,
+        }
+        for name, function in plots.items():
+            context.register_plot(name, function)
+
+
+def create_registry(*, discover: bool = True) -> PluginRegistry:
+    """Create a registry with core plots and optional third-party plugins."""
+    registry = PluginRegistry()
+    registry.register(CorePlotsPlugin())
+    if discover:
+        registry.discover()
+    return registry
+
+
+__all__ = [
+    "ENTRY_POINT_GROUP",
+    "PLUGIN_API_VERSION",
+    "CorePlotsPlugin",
+    "DuplicatePluginError",
+    "Plugin",
+    "PluginContext",
+    "PluginError",
+    "PluginRegistry",
+    "create_registry",
+]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,74 @@
+"""Contract tests for the first-class plugin surface."""
+
+import pytest
+
+from MatplotLibAPI.plugins import (
+    PLUGIN_API_VERSION,
+    DuplicatePluginError,
+    PluginContext,
+    PluginError,
+    PluginRegistry,
+    create_registry,
+)
+
+
+class ExamplePlugin:
+    """Small plugin used by the registry contract tests."""
+
+    name = "example"
+    api_version = PLUGIN_API_VERSION
+
+    def setup(self, context: PluginContext) -> None:
+        """Register one example plot."""
+        context.register_plot("example", lambda: "ok")
+
+
+def test_core_registry_exposes_stable_plots() -> None:
+    """The built-in plugin should expose the stable plotting API."""
+    registry = create_registry(discover=False)
+
+    assert registry.list_plugins() == ["core"]
+    assert "bar" in registry.context.list_plots()
+    assert callable(registry.context.get_plot("bar"))
+
+
+def test_custom_plugin_registration() -> None:
+    """Third-party plugins should register deterministic plot names."""
+    registry = PluginRegistry()
+    registry.register(ExamplePlugin())
+
+    assert registry.list_plugins() == ["example"]
+    assert registry.context.get_plot("example")() == "ok"
+
+
+def test_duplicate_plugin_is_rejected() -> None:
+    """A plugin name may only be registered once."""
+    registry = PluginRegistry()
+    registry.register(ExamplePlugin())
+
+    with pytest.raises(DuplicatePluginError):
+        registry.register(ExamplePlugin())
+
+
+def test_failed_setup_rolls_back_registered_plots() -> None:
+    """Partial setup must not mutate the registry."""
+
+    class BrokenPlugin:
+        name = "broken"
+        api_version = PLUGIN_API_VERSION
+
+        def setup(self, context: PluginContext) -> None:
+            context.register_plot("partial", lambda: None)
+            raise RuntimeError("boom")
+
+    registry = PluginRegistry()
+    with pytest.raises(RuntimeError):
+        registry.register(BrokenPlugin())
+
+    assert registry.context.list_plots() == []
+
+
+def test_unknown_plot_has_clear_error() -> None:
+    """Unknown plot lookup should fail with a plugin-specific error."""
+    with pytest.raises(PluginError, match="Unknown plot"):
+        PluginContext().get_plot("missing")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -4,8 +4,14 @@ import MatplotLibAPI
 
 
 EXPECTED_PUBLIC_API = {
+    "CorePlotsPlugin",
     "CorrelationMethod",
     "DataFrameAccessor",
+    "PLUGIN_API_VERSION",
+    "Plugin",
+    "PluginContext",
+    "PluginRegistry",
+    "create_registry",
     "fplot_area",
     "fplot_bar",
     "fplot_box_violin",


### PR DESCRIPTION
## Summary

- add a minimal typed `Plugin` protocol and versioned plugin API
- add deterministic, atomic plugin and plot registration
- expose installed plugin discovery through the `matplotlibapi.plugins` entry-point group
- ship a built-in `CorePlotsPlugin` covering the stable package-root plotting API
- export the plugin surface from the package root
- add focused contract tests for registration, duplicates, rollback, and lookup errors

## Design

The surface stays deliberately small. Plugins provide `name`, `api_version`, and `setup(context)`. The registry owns discovery and validation, while plotting implementations remain ordinary Python callables.

## Validation

GitHub CI should run the existing pytest, Pyright, pydocstyle, and formatting checks.