### PR TITLE
feat: make MatplotLibAPI a native Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "fatmambot33-matplotlibapi",
+  "interface": {
+    "displayName": "MatplotLibAPI"
+  },
+  "plugins": [
+    {
+      "name": "matplotlibapi",
+      "source": {
+        "source": "local",
+        "path": "./plugins/matplotlibapi"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Data & Analytics"
+    }
+  ]
+}

--- a/plugins/matplotlibapi/.codex-plugin/plugin.json
+++ b/plugins/matplotlibapi/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "matplotlibapi",
+  "version": "4.1.0",
+  "description": "Create reliable charts and visual analysis with MatplotLibAPI in Codex.",
+  "author": {
+    "name": "FaTmamBo33",
+    "url": "https://github.com/fatmambot33"
+  },
+  "homepage": "https://github.com/fatmambot33/MatplotLibAPI",
+  "repository": "https://github.com/fatmambot33/MatplotLibAPI",
+  "license": "MIT",
+  "keywords": ["matplotlib", "charts", "visualization", "data", "codex", "python"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "MatplotLibAPI",
+    "shortDescription": "Production-ready charts from Codex",
+    "longDescription": "Install MatplotLibAPI from Git and use its typed plotting registry to inspect data, choose a chart, render figures, and save reproducible outputs.",
+    "developerName": "FaTmamBo33",
+    "category": "Data & Analytics",
+    "capabilities": ["Read", "Interactive"],
+    "websiteURL": "https://github.com/fatmambot33/MatplotLibAPI",
+    "defaultPrompt": [
+      "Choose the best chart for this dataset.",
+      "Create a polished chart and save it.",
+      "Inspect available MatplotLibAPI plots."
+    ],
+    "brandColor": "#F97316"
+  }
+}

--- a/plugins/matplotlibapi/skills/matplotlibapi/SKILL.md
+++ b/plugins/matplotlibapi/skills/matplotlibapi/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: matplotlibapi
+description: Install and use MatplotLibAPI from Git to inspect tabular data, select appropriate visualizations, render charts, and save reproducible figures.
+---
+
+# MatplotLibAPI
+
+## Setup
+
+Ensure the current Python environment has the repository version installed:
+
+```bash
+python -m pip install --upgrade "git+https://github.com/fatmambot33/MatplotLibAPI.git"
+```
+
+Use the package's plugin registry as the primary discovery surface:
+
+```python
+from MatplotLibAPI import create_registry
+
+registry = create_registry()
+print(registry.context.list_plots())
+```
+
+## Workflow
+
+1. Inspect columns, dtypes, missing values, and row counts.
+2. Choose the simplest chart that answers the user's question.
+3. Prefer registered `fplot_*` helpers over custom plotting code.
+4. Keep transformations explicit and preserve the source data.
+5. Render headlessly when needed with `MPLBACKEND=Agg`.
+6. Save the figure to a clear output path and report that path.
+
+Use Matplotlib figures for static outputs and the registered Plotly helpers when interactive output materially improves the result.


### PR DESCRIPTION
## Summary

- add a repo-backed Codex marketplace
- add a validated `.codex-plugin/plugin.json` manifest
- add a reusable visualization skill
- provide Git installation and plugin-registry guidance

## Install

```bash
codex plugin marketplace add fatmambot33/MatplotLibAPI --ref main
codex plugin add matplotlibapi@fatmambot33-matplotlibapi
```
