### PR TITLE
feat: enforce the AI-native platform manifest

### DIFF
--- a/.github/workflows/ai-native-platform.yml
+++ b/.github/workflows/ai-native-platform.yml
@@ -1,0 +1,17 @@
+name: AI-native platform
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install PyYAML
+      - run: python scripts/validate_ai_native_platform.py

--- a/AI_NATIVE_PLATFORM.yaml
+++ b/AI_NATIVE_PLATFORM.yaml
@@ -1,0 +1,80 @@
+version: 1
+
+platform:
+  name: First Class AI Native Platform
+  required: true
+
+product:
+  name: MatplotLibAPI
+  ai_native: true
+  plugin_first: true
+  sdk_first: true
+  api_first: true
+  cli_first: true
+  mcp_first: false
+
+plugin:
+  enabled: true
+  codex:
+    supported: true
+    marketplace: true
+  discovery:
+    entry_points: true
+    manifest: true
+    capabilities: true
+  credentials:
+    required: false
+    local_only: true
+    env_file: .env
+    env_example: plugins/matplotlibapi/.env.example
+    required_variables: []
+    setup_command: null
+    validation_command: null
+    policy:
+      never_store_remote: true
+      never_commit: true
+      never_echo: true
+      require_gitignore: true
+      require_local_env: false
+
+commands:
+  required:
+    - validate
+    - test
+    - docs
+    - examples
+    - upgrade
+    - uninstall
+  recommended:
+    - eval
+    - benchmark
+
+interfaces:
+  sdk: true
+  cli: true
+  plugin: true
+  mcp: false
+  openai_tools: true
+  json_schema: true
+
+quality:
+  typed: true
+  tests: true
+  docs: true
+  examples: true
+  security_scan: true
+  compatibility_tests: true
+  ai_evaluations: true
+  benchmark: true
+
+release:
+  block_if_quality_fails: true
+  block_if_doctor_fails: false
+  block_if_plugin_invalid: true
+  validate_manifest: python scripts/validate_ai_native_platform.py
+
+agent:
+  guarantees:
+    - no_credentials_required
+    - deterministic_tool_discovery
+    - structured_outputs

--- a/scripts/validate_ai_native_platform.py
+++ b/scripts/validate_ai_native_platform.py
@@ -1,0 +1,90 @@
+"""Validate the repository AI-native platform contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+MANIFEST = Path("AI_NATIVE_PLATFORM.yaml")
+REQUIRED_TRUE_PATHS = (
+    ("platform", "required"),
+    ("product", "ai_native"),
+    ("product", "plugin_first"),
+    ("plugin", "enabled"),
+    ("plugin", "codex", "supported"),
+    ("plugin", "codex", "marketplace"),
+    ("plugin", "discovery", "entry_points"),
+    ("plugin", "discovery", "manifest"),
+    ("plugin", "credentials", "local_only"),
+    ("plugin", "credentials", "policy", "never_store_remote"),
+    ("plugin", "credentials", "policy", "never_commit"),
+    ("plugin", "credentials", "policy", "never_echo"),
+    ("interfaces", "sdk"),
+    ("interfaces", "cli"),
+    ("interfaces", "plugin"),
+    ("quality", "typed"),
+    ("quality", "tests"),
+    ("quality", "docs"),
+    ("release", "block_if_quality_fails"),
+    ("release", "block_if_plugin_invalid"),
+)
+REQUIRED_GUARANTEES = {"deterministic_tool_discovery", "structured_outputs"}
+
+
+def read_path(data: dict[str, Any], path: tuple[str, ...]) -> Any:
+    """Read one nested manifest value."""
+    current: Any = data
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            raise KeyError(".".join(path))
+        current = current[key]
+    return current
+
+
+def main() -> int:
+    """Validate the canonical manifest and return a process exit code."""
+    if not MANIFEST.is_file():
+        print(f"Missing required manifest: {MANIFEST}")
+        return 1
+    data = yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or data.get("version") != 1:
+        print("Manifest version must be 1")
+        return 1
+    errors: list[str] = []
+    for path in REQUIRED_TRUE_PATHS:
+        try:
+            if read_path(data, path) is not True:
+                errors.append(f"{'.'.join(path)} must be true")
+        except KeyError:
+            errors.append(f"missing {'.'.join(path)}")
+    commands = set(data.get("commands", {}).get("required", []))
+    for command in ("validate", "test", "docs", "examples", "upgrade", "uninstall"):
+        if command not in commands:
+            errors.append(f"commands.required must include {command}")
+    credentials = data.get("plugin", {}).get("credentials", {})
+    if credentials.get("required"):
+        for key in ("env_file", "env_example", "setup_command", "validation_command"):
+            if not credentials.get(key):
+                errors.append(f"plugin.credentials.{key} is required")
+        if not credentials.get("required_variables"):
+            errors.append("plugin.credentials.required_variables must not be empty")
+        for command in ("configure", "doctor"):
+            if command not in commands:
+                errors.append(f"credentialed products require command {command}")
+    guarantees = set(data.get("agent", {}).get("guarantees", []))
+    missing_guarantees = REQUIRED_GUARANTEES - guarantees
+    if missing_guarantees:
+        errors.append("missing agent guarantees: " + ", ".join(sorted(missing_guarantees)))
+    if errors:
+        print("AI-native platform manifest validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("AI-native platform manifest is valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add canonical `AI_NATIVE_PLATFORM.yaml`
- declare plugin, credential-free, interface, quality, release, and agent guarantees
- add a reusable manifest validator
- add a dedicated CI quality gate

The release contract now fails when required AI-native capabilities are removed.